### PR TITLE
Revise naming standards in navnestandard.md

### DIFF
--- a/docs/dbt-kodestandard/navnestandard.md
+++ b/docs/dbt-kodestandard/navnestandard.md
@@ -27,7 +27,7 @@ Unngå:
 | ----------- | ----------- |
 | `stg_aareg_arbeidsforhold`      | `key_person`       |
 | `int_arbeid_arbeidsforhold_historisert`   | `id_person`        |
-|`dim_arbeidsgiver`   | `flagg_gjeldende`        |
+|`dim_arbeidsgiver`   | `flagg_gyldig`        |
 |`dim_person`   | `dato_gyldig_fom`        |
 |`fak_arbeidsforhold`   | `dato_gyldig_tom`        |
 |`obt_arbeid_personstatus`   | `arbeidsforhold_status`        |

--- a/docs/dbt-kodestandard/navnestandard.md
+++ b/docs/dbt-kodestandard/navnestandard.md
@@ -33,7 +33,7 @@ Unngå:
 |`obt_arbeid_personstatus`   | `arbeidsforhold_status`        |
 
 
-## Modellprefiks for eksponerte modeller
+## Modellprefiks for eksponerte modeller i marts
 
 For modeller som andre skal lese og bygge videre på, bruker vi følgende hovedmønstre:
 
@@ -73,12 +73,11 @@ Komponentnavn skal bare tas med når det bidrar til avklaring. Vi skal ikke legg
 
 ## Navngivning av interne dbt-modeller
 
-For interne modeller i dbt anbefaler vi et enklere og velkjent mønster:
+For interne modeller i dbt anbefaler vi følgende mønster, hvor stg og base har dobbel underscore for å enklere skille mellom kildesystem og objekt i kildesystem, når man ser på objekter i databasen.:
 
-- `stg_<kilde>_<objekt>` for stagingmodeller
+- `stg_<kilde>__<objekt>` for stagingmodeller
 - `int_<tema>_<formaal>` for interne mellommodeller
-- `base_<kilde>_<objekt>` kun der det er behov for et eksplisitt base-lag
-- `<tema>_<formaal>` for mart? 
+- `base_<kilde>__<objekt>` kun der det er behov for et eksplisitt base-lag
 
 Eksempler:
 

--- a/docs/dbt-kodestandard/navnestandard.md
+++ b/docs/dbt-kodestandard/navnestandard.md
@@ -27,7 +27,7 @@ Unngå:
 | ----------- | ----------- |
 | `stg_aareg_arbeidsforhold`      | `key_person`       |
 | `int_arbeid_arbeidsforhold_historisert`   | `id_person`        |
-|`dim_arbeidsgiver`   | `flg_gjeldende`        |
+|`dim_arbeidsgiver`   | `flagg_gjeldende`        |
 |`dim_person`   | `dato_gyldig_fom`        |
 |`fak_arbeidsforhold`   | `dato_gyldig_tom`        |
 |`obt_arbeid_personstatus`   | `arbeidsforhold_status`        |
@@ -101,7 +101,7 @@ Kolonner skal navngis etter hva de betyr, ikke hvor de kommer fra. Da det kan v�
 - dato_ som prefiks for datoer.
 - tid_ som prefiks for tidspunkt.
 - ts_ som prefiks for timestamps (dato og tid)
-- flg_ som prefiks for flagg-kolonner, enten med true/false eller med enten/eller kategoriseringsinnhold.
+- flagg_ som prefiks for flagg-kolonner, enten med true/false eller med enten/eller kategoriseringsinnhold.
 - lastet_ som prefiks for systemfelt, for når dataene sist ble lastet i modellen. ?
 - _navn som suffiks for å spesifisere tekstkolonner hvis beskrivelsen ikke er god nok alene. For eks "land" kan være en god nok beskrivelse istedenfor land_navn?
 - kildesystem som kolonnenavn hvis det er viktig å spesifisere kilde
@@ -152,9 +152,9 @@ Anbefalte suffiks når de gir mening:
 
 For boolske verdier foretrekkes navn som er enkle å forstå:
 
-- `flg_aktiv`
-- `flg_gjeldende`
-- `flg_vedtak`
+- `flagg_aktiv`
+- `flagg_gjeldende`
+- `flagg_vedtak`
 
 ### Historikkolonner
 Tidsstempel: 

--- a/docs/dbt-kodestandard/navnestandard.md
+++ b/docs/dbt-kodestandard/navnestandard.md
@@ -98,10 +98,10 @@ Kolonner skal navngis etter hva de betyr, ikke hvor de kommer fra. Da det kan v�
 - id_ som prefiks for naturlige id-felter.
 - key_ som prefiks for surrogate/syntetiske nøkler.
 - dato_ som prefiks for datoer.
-- tid_ som prefiks for dato med tidspunkt med millisekunder.
-- ts_ som prefiks for dato med timestamps med nanosekunder.?
+- tid_ som prefiks for dato med tidspunkt med millisekunder presisjon.
+- ts_ som prefiks for dato med timestamps med opptil nanosekunder presisjon.
 - flagg_ som prefiks for flagg-kolonner, enten med true/false eller med enten/eller kategoriseringsinnhold.
-- lastet_ som prefiks for systemfelt, for når dataene sist ble lastet i modellen. ?
+- lastet_ som prefiks for systemfelt, for når dataene sist ble lastet i modellen.
 - _navn som suffiks for å spesifisere tekstkolonner hvis beskrivelsen ikke er god nok alene. For eks "land" kan være en god nok beskrivelse istedenfor land_navn?
 - kildesystem som kolonnenavn hvis det er viktig å spesifisere kilde
 

--- a/docs/dbt-kodestandard/navnestandard.md
+++ b/docs/dbt-kodestandard/navnestandard.md
@@ -73,16 +73,16 @@ Komponentnavn skal bare tas med når det bidrar til avklaring. Vi skal ikke legg
 
 ## Navngivning av interne dbt-modeller
 
-For interne modeller i dbt anbefaler vi følgende mønster, hvor stg og base har dobbel underscore for å enklere skille mellom kildesystem og objekt i kildesystem, når man ser på objekter i databasen.:
+For interne modeller i dbt anbefaler vi følgende mønster, hvor stg og base har dobbel underscore for å enklere skille mellom kildesystem og objekt i kildesystem, når man ser på objekter i databasen:
 
 - `stg_<kilde>__<objekt>` for stagingmodeller
-- `int_<tema>_<formaal>` for interne mellommodeller
 - `base_<kilde>__<objekt>` kun der det er behov for et eksplisitt base-lag
+- `int_<tema>_<formaal>` for interne mellommodeller
 
 Eksempler:
 
-- `stg_aareg_arbeidsforhold`
-- `stg_pp01_vedtak`
+- `stg_aareg__arbeidsforhold`
+- `stg_pp01__vedtak`
 - `int_oppfolging_person_beriket`
 
 Disse modellene er interne arbeidsflater. Her er det lov å være mer teknisk, men navnene skal fortsatt være forståelige.

--- a/docs/dbt-kodestandard/navnestandard.md
+++ b/docs/dbt-kodestandard/navnestandard.md
@@ -4,13 +4,42 @@ Denne siden beskriver hvordan navnestandarden implementeres i dbt-prosjektet.
 
 For bakgrunn og produktregler, se [../dataprodukt/navnestandard.md](../dataprodukt/navnestandard.md).
 
+- Benytt norsk språk.
+- Benytt små bokstaver.
+- Benytt snake_case.
+- Oversett æ med ae, ø med o, å med aa.
+- Modellnavn skrives i entall når granulariteten er én forekomst per rad.
+- Forkortelser brukes bare når de er allment forstått i domenet.
+- Samme kolonne skal hete det samme i dimensjon, fakta og OBT når den betyr det samme.
+- Eksponerte modeller skal ikke lekke gamle lagbegreper som forkammer, kjerne og torg inn i navnene.
+
+Unngå:
+- Vi bruker ikke `DIM_`, `FAK_` og `AGG_` i store bokstaver.
+- Vi bruker ikke tekniske prefiks som sier noe om fysisk databaseobjekt.
+- Vi bruker ikke kildesystemnavn i eksponerte modellnavn, med mindre modellen faktisk representerer kilden som kilde.
+- Vi bruker ikke både teknisk og funksjonelt navn i samme modellnavn.
+
+
+
+### Eksempel på komponenter og kolonnenavn
+
+| Komponenter      | Kolonnenavn |
+| ----------- | ----------- |
+| `stg_aareg_arbeidsforhold`      | `key_person`       |
+| `int_arbeid_arbeidsforhold_historisert`   | `id_person`        |
+|`dim_arbeidsgiver`   | `flg_gjeldende`        |
+|`dim_person`   | `dato_gyldig_fom`        |
+|`fak_arbeidsforhold`   | `dato_gyldig_tom`        |
+|`obt_arbeid_personstatus`   | `arbeidsforhold_status`        |
+
+
 ## Modellprefiks for eksponerte modeller
 
 For modeller som andre skal lese og bygge videre på, bruker vi følgende hovedmønstre:
 
 - `dim_<navn>` for dimensjoner
 - `fak_<navn>` for fakta
-- `obt_<navn>` for OBT-er
+- `obt_<navn>` for OBT-er (One Big Table)
 - `kobling_<navn>` for koblingstabeller når mange-til-mange må modelleres eksplisitt
 
 Eksempler:
@@ -38,28 +67,24 @@ Eksempler:
 - `fak_arbeid_vedtak`
 - `obt_arbeid_personstatus`
 
-Komponentnavn skal bare tas med når det gir faktisk avklaring. Vi skal ikke legge på domene-prefiks av gammel vane.
+Komponentnavn skal bare tas med når det bidrar til avklaring. Vi skal ikke legge på domene-prefiks av gammel vane.
 
-## Hva vi ikke gjør
 
-- Vi bruker ikke `DIM_`, `FAK_` og `AGG_` i store bokstaver.
-- Vi bruker ikke tekniske prefiks som sier noe om fysisk databaseobjekt.
-- Vi bruker ikke kildesystemnavn i eksponerte modellnavn, med mindre modellen faktisk representerer kilden som kilde.
-- Vi bruker ikke både teknisk og funksjonelt navn i samme modellnavn.
 
 ## Navngivning av interne dbt-modeller
 
 For interne modeller i dbt anbefaler vi et enklere og velkjent mønster:
 
-- `stg_<kilde>__<objekt>` for stagingmodeller
-- `int_<tema>__<formaal>` for interne mellommodeller
-- `base_<kilde>__<objekt>` kun der det er behov for et eksplisitt base-lag
+- `stg_<kilde>_<objekt>` for stagingmodeller
+- `int_<tema>_<formaal>` for interne mellommodeller
+- `base_<kilde>_<objekt>` kun der det er behov for et eksplisitt base-lag
+- `<tema>_<formaal>` for mart? 
 
 Eksempler:
 
-- `stg_aareg__arbeidsforhold`
-- `stg_pp01__vedtak`
-- `int_oppfolging__person_beriket`
+- `stg_aareg_arbeidsforhold`
+- `stg_pp01_vedtak`
+- `int_oppfolging_person_beriket`
 
 Disse modellene er interne arbeidsflater. Her er det lov å være mer teknisk, men navnene skal fortsatt være forståelige.
 
@@ -69,35 +94,47 @@ Kolonnenavn er viktigere enn tabellnavn. Det er kolonnene som faktisk blir brukt
 
 ### Grunnregel
 
-Kolonner skal navngis etter hva de betyr, ikke hvor de kommer fra.
+Kolonner skal navngis etter hva de betyr, ikke hvor de kommer fra. Da det kan være lettere å søke frem kolonner basert på grunnleggende prefix, samt at flere systemer alfabetiserer kolonner, benyttes disse grunnleggende kolonnenavn/prefiks for velbrukte kolonner:
 
+- id_ som prefiks for naturlige id-felter.
+- key_ som prefiks for surrogate/syntetiske nøkler.
+- dato_ som prefiks for datoer.
+- tid_ som prefiks for tidspunkt.
+- ts_ som prefiks for timestamps (dato og tid)
+- flg_ som prefiks for flagg-kolonner, enten med true/false eller med enten/eller kategoriseringsinnhold.
+- lastet_ som prefiks for systemfelt, for når dataene sist ble lastet i modellen. ?
+- _navn som suffiks for å spesifisere tekstkolonner hvis beskrivelsen ikke er god nok alene. For eks "land" kan være en god nok beskrivelse istedenfor land_navn?
+- kildesystem som kolonnenavn hvis det er viktig å spesifisere kilde
+
+Vær presis med navngivning, slik at kolonnenavnet representerer faktisk innhold.
 Eksempler:
 
-- bruk `person_id`, ikke `aktorid` hvis kolonnen faktisk representerer personens identifikator i modellen
-- bruk `vedtak_dato`, ikke `behandlingsdato`, hvis det er vedtakstidspunkt modellen uttrykker
+- bruk `id_person`, ikke `aktorid` hvis kolonnen faktisk representerer personens identifikator i modellen
+- bruk `dato_vedtak`, ikke `behandlingsdato`, hvis det er vedtakstidspunkt modellen uttrykker
 - bruk `arbeidsgiver_navn`, ikke `navn`, når kolonnen ellers blir tvetydig
 
 ### Nøkler
 
 Vi skiller tydelig mellom forretningsnøkler og surrogate nøkler.
 
-- Surrogate nøkler i dimensjoner navngis `<entitet>_key`
+- Surrogate nøkler i dimensjoner navngis `key_<entitet>`
 - Fremmednøkler i fakta bruker samme navn som dimensjonen peker på
-- Forretningsnøkler navngis `<entitet>_id` eller `<entitet>_<kode/navn>` når det er mer presist
+- Forretningsnøkler navngis `id_<entitet>` eller `<entitet>_<kode/navn>` når det er mer presist
+- Vi bruker ikke `pk_`, `fk_` eller `ek_` som kolonneprefiks i eksponerte dbt-modeller. Slike navn beskriver databaseimplementasjon, ikke informasjonen brukeren forholder seg til. 
 
 Eksempler:
 
-- `person_key`
-- `arbeidsgiver_key`
-- `person_id`
-- `organisasjon_id`
-- `vedtak_id`
+- `key_person`
+- `key_arbeidsgiver`
+- `id_person`
+- `id_organisasjon`
+- `id_vedtak`
 
-Vi bruker ikke `pk_`, `fk_` eller `ek_` som kolonneprefiks i eksponerte dbt-modeller. Slike navn beskriver databaseimplementasjon, ikke informasjonen brukeren forholder seg til.
+
 
 ### Beskrivende attributter
 
-Beskrivende kolonner skal være eksplisitte og selvforklarende.
+Beskrivende kolonner skal være eksplisitte og selvforklarende. Dette er spesielt viktig i OBT-tabeller, hvor det er viktig å unngå tvetydige navn, og at kolonner skal kunne forstås uten kjennskap til de underliggende dimensjonene.
 
 - bruk `person_navn`, ikke bare `navn`
 - bruk `vedtak_status`, ikke bare `status`
@@ -106,113 +143,26 @@ Beskrivende kolonner skal være eksplisitte og selvforklarende.
 
 Anbefalte suffiks når de gir mening:
 
-- `_id` for identifikator
-- `_key` for surrogate nøkkel
 - `_kode` for kodeverdier
 - `_navn` for lesbare navn
-- `_dato` for dato uten klokkeslett
 - `_tidspunkt` for tidspunkt med klokkeslett
 - `_belop` for beløp
 - `_antall` for tellinger
 - `_andel` eller `_prosent` for forholdstall
-- `_flagg` eller `er_<egenskap>` for boolske verdier
 
-For boolske verdier foretrekkes navn som leses naturlig:
+For boolske verdier foretrekkes navn som er enkle å forstå:
 
-- `er_aktiv`
-- `er_gjeldende`
-- `har_vedtak`
+- `flg_aktiv`
+- `flg_gjeldende`
+- `flg_vedtak`
 
-## Historikkolonner
+### Historikkolonner
+Tidsstempel: 
 
-Når historikken føres per døgn, bruker vi normalt:
-
-- `gyldig_fom_dato`
-- `gyldig_tom_dato`
-
-- `oppdatert_dato`
-- `lastet_dato`
-
-Når historikken føres med sekundoppløsning, bruker vi normalt:
-
-- `gyldig_fom_tid`
-- `gyldig_til_tid`
-
-- `oppdatert_tid`
-- `lastet_tid`
-
-Når historikken føres med timestamp-oppløsning, bruker vi normalt:
-
-- `gyldig_fom_ts`
-- `gyldig_til_ts`
-
-- `oppdatert_ts`
-- `lastet_ts`
-
-Andre vanlige historikkolonner er:
-
-I tillegg til gyldighetsintervall bruker vi ofte:
-
-- `er_gjeldende`
-- `kildesystem`
-
-Hvis modellen uttrykker funksjonell gyldighet i tillegg til teknisk gyldighet, skal dette fremgå tydelig:
-
-- `funksjonell_fra_dato`
-- `funksjonell_til_dato`
-
-## Kolonner i OBT-er
-
-I OBT-er skal kolonnenavn være ekstra tydelige, fordi disse modellene ofte brukes direkte av analytikere og rapporter.
-
-- Kolonner skal kunne forstås uten kjennskap til de underliggende dimensjonene.
-- Tvetydige navn som `status`, `dato`, `navn` og `id` skal ikke brukes alene.
-- Kolonner fra ulike områder skal ha prefiks eller fullt navn som gjør dem unike.
-
-Eksempler:
-
-- `person_id`
-- `person_navn`
-- `arbeidsgiver_navn`
-- `vedtak_status`
-- `utbetaling_belop`
-
-## Konkrete regler
-
-- Modellnavn skrives med små bokstaver og underscore.
-- Modellnavn skrives i entall når granulariteten er én forekomst per rad.
-- Kolonnenavn skrives med små bokstaver og underscore.
-- Forkortelser brukes bare når de er allment forstått i domenet.
-- Samme kolonne skal hete det samme i dimensjon, fakta og OBT når den betyr det samme.
-- Eksponerte modeller skal ikke lekke gamle lagbegreper som forkammer, kjerne og torg inn i navnene.
-
-## Eksempel
-
-Et mulig mønster for en komponent kan se slik ut:
-
-- `stg_aareg__arbeidsforhold`
-- `int_arbeid__arbeidsforhold_historisert`
-- `dim_arbeidsgiver`
-- `dim_person`
-- `fak_arbeidsforhold`
-- `obt_arbeid_personstatus`
-
-Med tilhørende kolonner:
-
-- `person_key`
-- `person_id`
-- `arbeidsgiver_key`
-- `arbeidsgiver_id`
-- `arbeidsforhold_id`
-- `arbeidsforhold_status`
-- `gyldig_fra_dato`
-- `gyldig_til_dato`
-- `er_gjeldende`
-
-## Kort oppsummert
-
-- Bruk `dim_`, `fak_`, `kobling_` og `obt_` for eksponerte modeller.
-- Bruk `stg_`, `int_` og eventuelt `base_` for interne modeller.
-- Bruk `<entitet>_key` for surrogate nøkler og `<entitet>_id` for forretningsnøkler.
-- La historikkfeltene følge ett tydelig mønster i prosjektet.
-
+| Kolonneinnhold      | dato | tid     | timestamp     |
+| ----------- | ----------- | ----------- | ----------- |
+| Gyldig fra og med   | `dato_gyldig_fom` | `tid_gyldig_fom`       | `ts_gyldig_fom`       |
+| Gyldig til og med  | `dato_gyldig_tom` | `tid_gyldig_til`        |`ts_gyldig_til`        |
+| Oppdatert dato  | `dato_oppdatert` | `tid_oppdatert`        | `ts_oppdatert`        |
+| Funksjonell/teknisk gyldighet fra  | `dato_funksjonell_fra` | `tid_funksjonell_fra`        | `ts_funksjonell_fra`        |
+| Funksjonell/teknisk gyldighet til  | `dato_funksjonell_til` | `tid_funksjonell_til`        | `ts_funksjonell_til`        |

--- a/docs/dbt-kodestandard/navnestandard.md
+++ b/docs/dbt-kodestandard/navnestandard.md
@@ -98,8 +98,8 @@ Kolonner skal navngis etter hva de betyr, ikke hvor de kommer fra. Da det kan v�
 - id_ som prefiks for naturlige id-felter.
 - key_ som prefiks for surrogate/syntetiske nøkler.
 - dato_ som prefiks for datoer.
-- tid_ som prefiks for tidspunkt.
-- ts_ som prefiks for timestamps (dato og tid)
+- tid_ som prefiks for dato med tidspunkt med millisekunder.
+- ts_ som prefiks for dato med timestamps med nanosekunder.?
 - flagg_ som prefiks for flagg-kolonner, enten med true/false eller med enten/eller kategoriseringsinnhold.
 - lastet_ som prefiks for systemfelt, for når dataene sist ble lastet i modellen. ?
 - _navn som suffiks for å spesifisere tekstkolonner hvis beskrivelsen ikke er god nok alene. For eks "land" kan være en god nok beskrivelse istedenfor land_navn?

--- a/docs/dbt-kodestandard/navnestandard.md
+++ b/docs/dbt-kodestandard/navnestandard.md
@@ -153,7 +153,7 @@ Anbefalte suffiks når de gir mening:
 For boolske verdier foretrekkes navn som er enkle å forstå:
 
 - `flagg_aktiv`
-- `flagg_gjeldende`
+- `flagg_gyldig`
 - `flagg_vedtak`
 
 ### Historikkolonner


### PR DESCRIPTION
Updated naming conventions and guidelines for dbt models and columns, ensuring clarity and consistency in naming standards.